### PR TITLE
fix[monitor]: Handle TickMsg at top level

### DIFF
--- a/cmd/monitor/detailed_process.go
+++ b/cmd/monitor/detailed_process.go
@@ -41,9 +41,6 @@ func (m *model_process_detailed) Init() tea.Cmd {
 func (m *model_process_detailed) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
-	case TickMsg:
-		m.updateDetailedTable(nil)
-		return doTick()
 	case tea.KeyMsg:
 		m.table_detailed, cmd = m.table_detailed.Update(msg)
 	}

--- a/cmd/monitor/detailed_topic.go
+++ b/cmd/monitor/detailed_topic.go
@@ -49,9 +49,6 @@ func (m *model_detailed) Init() tea.Cmd {
 func (m *model_detailed) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
-	case TickMsg:
-		m.updateDetailedTable(nil)
-		return doTick()
 	case tea.KeyMsg:
 		m.table_detailed, cmd = m.table_detailed.Update(msg)
 	}
@@ -60,6 +57,10 @@ func (m *model_detailed) Update(msg tea.Msg) tea.Cmd {
 
 func (m *model_detailed) View() string {
 	return baseStyle.Render(m.table_detailed.View()) + "\n" + m.table_detailed.HelpView()
+}
+
+func (m *model_detailed) Refresh() {
+	m.updateDetailedTable(nil)
 }
 
 func (m *model_detailed) updateDetailedTable(msg tea.Msg) {

--- a/cmd/monitor/processes_list.go
+++ b/cmd/monitor/processes_list.go
@@ -68,9 +68,6 @@ func (m *model_processes) Update(msg tea.Msg) tea.Cmd {
 	switch m.subpage {
 	case subpage_proc_main:
 		switch msg := msg.(type) {
-		case TickMsg:
-			m.Refresh()
-			return doTick()
 		case tea.KeyMsg:
 			m.updateTable(msg)
 		}
@@ -91,7 +88,12 @@ func (m *model_processes) View() string {
 }
 
 func (m *model_processes) Refresh() {
-	m.updateTable(nil)
+	switch m.subpage {
+	case subpage_proc_detailed:
+		m.model_detailed.Refresh()
+	default:
+		m.updateTable(nil)
+	}
 }
 
 func (m *model_processes) navDown() {

--- a/cmd/monitor/tea.go
+++ b/cmd/monitor/tea.go
@@ -56,13 +56,17 @@ func (m *model) updatePage(msg tea.Msg) tea.Cmd {
 }
 
 func (m *model) transitionTo(newPage Page) {
-	switch newPage {
+	m.page = newPage
+	m.refresh()
+}
+
+func (m *model) refresh() {
+	switch m.page {
 	case page_topics:
 		m.model_topics.Refresh()
 	case page_processes:
 		m.model_processes.Refresh()
 	}
-	m.page = newPage
 }
 
 func (m *model) Init() tea.Cmd {
@@ -72,6 +76,9 @@ func (m *model) Init() tea.Cmd {
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
+	case TickMsg:
+		m.refresh()
+		cmd = doTick()
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":

--- a/cmd/monitor/topics_list.go
+++ b/cmd/monitor/topics_list.go
@@ -165,7 +165,12 @@ func (m *model_topics) GetSelectedId() (string, bool, error) {
 }
 
 func (m *model_topics) Refresh() {
-	m.updateTopicsTable(nil)
+	switch m.subpage {
+	case subpage_topic_detailed:
+		m.model_detailed.Refresh()
+	default:
+		m.updateTopicsTable(nil)
+	}
 }
 
 func (m *model_topics) Init() tea.Cmd {
@@ -191,9 +196,6 @@ func (m *model_topics) Update(msg tea.Msg) tea.Cmd {
 	switch m.subpage {
 	case subpage_topic_main:
 		switch msg := msg.(type) {
-		case TickMsg:
-			m.Refresh()
-			return doTick()
 		case tea.KeyMsg:
 			switch {
 			case key.Matches(msg, m.keymap.Help):


### PR DESCRIPTION
New ticks would not be dispatched when looking at the placeholder tabs.
Handling of refreshes from TickMsg is now driven from the top level.