### PR TITLE
feat[monitor]: Temporary config tab implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Features:
   - [x] Detailed topic view
   - [ ] Live message view
 - [x] Show Services
-- [ ] Show Hosts
+- [x] Show Hosts
 - [x] Show Processes
 - [x] Show eCAL Logs
 - [ ] Show config

--- a/cmd/monitor/config_page.go
+++ b/cmd/monitor/config_page.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/DownerCase/ecal-go/ecal"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type model_config struct {
+	viewport viewport.Model
+}
+
+func NewConfigModel() *model_config {
+	viewport := viewport.New(85, 10)
+	viewport.SetContent(ecal.GetConfig())
+	viewport.Style = baseStyle
+	return &model_config{
+		viewport: viewport,
+	}
+}
+
+func (m *model_config) Refresh() {}
+
+func (m *model_config) Update(msg tea.Msg) (cmd tea.Cmd) {
+	m.viewport, cmd = m.viewport.Update(msg)
+	return cmd
+}
+
+func (m *model_config) View() string {
+	return m.viewport.View()
+}

--- a/cmd/monitor/tea.go
+++ b/cmd/monitor/tea.go
@@ -39,7 +39,7 @@ func newModel() *model {
 	pagesMap[page_hosts] = NewHostsModel()
 	pagesMap[page_processes] = NewProcessesModel()
 	pagesMap[page_logs] = NewLogsModel()
-	pagesMap[page_system] = &PlaceholderModel{"System Placeholder"}
+	pagesMap[page_system] = NewConfigModel()
 	pagesMap[page_about] = &PlaceholderModel{"About Placeholder"}
 	return &model{
 		page:  page_topics,
@@ -114,7 +114,7 @@ func (m *model) View() string {
 		"3: Hosts",
 		"4: Processes",
 		"5: Logs",
-		"6: System",
+		"6: Config",
 		"7: About",
 	}
 	s.WriteString("\n")

--- a/ecal/callback.go
+++ b/ecal/callback.go
@@ -1,0 +1,13 @@
+package ecal
+
+//#include <stdint.h>
+import "C"
+import (
+	"runtime/cgo"
+)
+
+//export goCopyString
+func goCopyString(handle C.uintptr_t, data *C.char) {
+	d := cgo.Handle(handle).Value().(*string)
+	*d = C.GoString(data)
+}

--- a/ecal/core.cpp
+++ b/ecal/core.cpp
@@ -3,6 +3,11 @@
 #include <ecal/config/configuration.h>
 #include <ecal/ecal_core.h>
 #include <ecal/ecal_defs.h>
+#include <ecal/ecal_process.h>
+
+extern "C" {
+extern void goCopyString(uintptr_t, const char *const);
+}
 
 namespace {
 eCAL::Configuration convertConfig(CConfig &config) {
@@ -43,3 +48,9 @@ bool SetUnitName(const char *unit_name) {
 }
 
 bool Ok() { return eCAL::Ok(); }
+
+void GetConfig(uintptr_t handle) {
+  std::string cfg{};
+  eCAL::Process::DumpConfig(cfg);
+  goCopyString(handle, cfg.c_str());
+}

--- a/ecal/core.go
+++ b/ecal/core.go
@@ -4,7 +4,10 @@ package ecal
 // #include "core.h"
 // #include <stdlib.h>
 import "C"
-import "unsafe"
+import (
+	"runtime/cgo"
+	"unsafe"
+)
 
 const (
 	// eCAL Components
@@ -85,4 +88,14 @@ func SetUnitName(unit_name string) bool {
 }
 func Ok() bool {
 	return bool(C.Ok())
+}
+
+// TODO: Reimplement with a proper config serialization as eCAL::DumpConfig()
+// is planned to be removed!
+func GetConfig() string {
+	var cfg string
+	handle := cgo.NewHandle(&cfg)
+	defer handle.Delete()
+	C.GetConfig(C.uintptr_t(handle))
+	return cfg
 }

--- a/ecal/core.h
+++ b/ecal/core.h
@@ -2,6 +2,7 @@
 #define ECAL_GO_CORE_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +36,8 @@ bool IsInitialized(void);
 bool IsComponentInitialized(unsigned int component);
 bool SetUnitName(const char *unit_name);
 bool Ok(void);
+
+void GetConfig(uintptr_t handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Will replace with a proper version that doesn't rely on `eCAL::DumpConfig()` as it will be removed.