### PR TITLE
refactor: Use opaque ptr for CPublisher

### DIFF
--- a/cmd/throughput/main.go
+++ b/cmd/throughput/main.go
@@ -64,7 +64,6 @@ func measureReceive(wg *sync.WaitGroup, cancel context.CancelFunc) {
 	defer wg.Done()
 	defer subscriber.Delete()
 
-	collectionDuration := 4 * time.Second
 	bytesReceived := 0
 	counter := 0
 
@@ -81,13 +80,14 @@ func measureReceive(wg *sync.WaitGroup, cancel context.CancelFunc) {
 	bytesReceived = 0
 	counter = 0
 
-	<-time.After(collectionDuration)
+	<-time.After(40 * time.Second)
 
 	bytesSnapshot := bytesReceived
 	after := time.Now()
 
 	p := message.NewPrinter(language.English)
-	p.Printf("Received %d bytes in %v seconds over %d messages\n", bytesSnapshot, collectionDuration, counter)
-	p.Printf("Total: %.0f MB/s\n", float64(bytesSnapshot/1024/1024)/after.Sub(before).Seconds())
+	captureDuration := after.Sub(before).Seconds()
+	p.Printf("Received %d bytes in %.2f seconds over %d messages\n", bytesSnapshot, captureDuration, counter)
+	p.Printf("Total: %.0f MB/s\n", float64(bytesSnapshot/1024/1024)/captureDuration)
 	cancel()
 }

--- a/ecal/publisher/cgo_wrapping.go
+++ b/ecal/publisher/cgo_wrapping.go
@@ -2,14 +2,12 @@
 package publisher
 
 // #include "publisher.h"
-// bool GoNewPublisher(
-//  uintptr_t handle,
+// void *GoNewPublisher(
 //  _GoString_ topic,
 //  _GoString_ name, _GoString_ encoding,
 //  const char* const descriptor, size_t descriptor_len
 // ) {
 //  return NewPublisher(
-//    handle,
 //    _GoStringPtr(topic), _GoStringLen(topic),
 //    _GoStringPtr(name), _GoStringLen(name),
 //    _GoStringPtr(encoding), _GoStringLen(encoding),

--- a/ecal/publisher/publisher.cpp
+++ b/ecal/publisher/publisher.cpp
@@ -2,16 +2,14 @@
 
 #include <ecal/pubsub/publisher.h>
 
-#include "internal/handle_map.hpp"
+void DestroyPublisher(void *publisher) {
+  if (publisher == nullptr) {
+    return;
+  }
+  delete static_cast<eCAL::CPublisher*>(publisher);
+}
 
-namespace {
-handle_map<eCAL::CPublisher> publishers{};
-} // namespace
-
-bool DestroyPublisher(uintptr_t handle) { return publishers.erase(handle); }
-
-bool NewPublisher(
-    uintptr_t handle,
+void *NewPublisher(
     const char *const topic,
     size_t topic_len,
     const char *const datatype_name,
@@ -21,8 +19,7 @@ bool NewPublisher(
     const char *const datatype_descriptor,
     size_t datatype_descriptor_len
 ) {
-  const auto [it, added] = publishers.emplace(
-      handle,
+  return new eCAL::CPublisher(
       std::string(topic, topic_len),
       eCAL::SDataTypeInformation{
           std::string(datatype_name, datatype_name_len),
@@ -30,13 +27,11 @@ bool NewPublisher(
           std::string(datatype_descriptor, datatype_descriptor_len)
       }
   );
-  return added;
 }
 
-void PublisherSend(uintptr_t handle, void *buf, size_t len) {
-  auto *publisher = publishers.find(handle);
+void PublisherSend(void *publisher, void *buf, size_t len) {
   if (publisher == nullptr) {
     return;
   }
-  publisher->Send(buf, len);
+  static_cast<eCAL::CPublisher*>(publisher)->Send(buf, len);
 }

--- a/ecal/publisher/publisher.go
+++ b/ecal/publisher/publisher.go
@@ -76,6 +76,8 @@ func (p *Publisher) IsStopped() bool {
 
 func (p *Publisher) sendMessages() {
 	for msg := range p.Messages {
+		// #cgo noescape PublisherSend
+		// #cgo nocallback PublisherSend
 		C.PublisherSend(p.handle, unsafe.Pointer(&msg[0]), C.size_t(len(msg)))
 	}
 	p.closed <- true

--- a/ecal/publisher/publisher.h
+++ b/ecal/publisher/publisher.h
@@ -9,20 +9,19 @@
 extern "C" {
 #endif
 
-bool NewPublisher(
-    uintptr_t handle,
-    const char *const topic,
+void *NewPublisher(
+    const char *topic,
     size_t topic_len,
-    const char *const datatype_name,
+    const char *datatype_name,
     size_t datatype_name_len,
-    const char *const datatype_encoding,
+    const char *datatype_encoding,
     size_t datatype_encoding_len,
-    const char *const datatype_descriptor,
+    const char *datatype_descriptor,
     size_t datatype_descriptor_len
 );
-bool DestroyPublisher(uintptr_t handle);
+void DestroyPublisher(void* publisher);
 
-void PublisherSend(uintptr_t handle, void *buf, size_t len);
+void PublisherSend(void* publisher, void *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/ecal/subscriber/subscriber.h
+++ b/ecal/subscriber/subscriber.h
@@ -11,13 +11,13 @@ extern "C" {
 
 bool NewSubscriber(
     uintptr_t handle,
-    const char *const topic,
+    const char *topic,
     size_t topic_len,
-    const char *const datatype_name,
+    const char *datatype_name,
     size_t datatype_name_len,
-    const char *const datatype_encoding,
+    const char *datatype_encoding,
     size_t datatype_encoding_len,
-    const char *const datatype_descriptor,
+    const char *datatype_descriptor,
     size_t datatype_descriptor_len
 );
 


### PR DESCRIPTION
Using `cgo.Handle` isn't needed for the publisher as it doesn't later call back to Go. Saves the "expensive" map lookup every time you want to send a message.

Also makes the throughput benchmark more accurate by measuring more carefully.

Makes use of new cgo annotations in Go 1.24 to optimize the calling of the C PublisherSend function (not that it makes a measurable difference...)